### PR TITLE
qca-nss-ecm: fix dependency issue

### DIFF
--- a/qca/qca-nss-ecm/Makefile
+++ b/qca/qca-nss-ecm/Makefile
@@ -24,6 +24,7 @@ define KernelPackage/qca-nss-ecm
 	+kmod-ipt-conntrack \
 	+kmod-ipt-physdev \
 	+iptables-mod-physdev \
+	+kmod-ppp \
 	+kmod-pppoe
   TITLE:=QCA NSS Enhanced Connection Manager (ECM)
   FILES:=$(PKG_BUILD_DIR)/*.ko


### PR DESCRIPTION
This commit fixes a dependency issue that was not allowing qca-nss-ecm
to show up in menuconfig unless kmod-ppp was selected


Signed-off-by: Tiago Gaspar <tiagogaspar8@gmail.com>