### PR TITLE
qca-nss-clients: fix dependency issue

### DIFF
--- a/qca/qca-nss-clients/Makefile
+++ b/qca/qca-nss-clients/Makefile
@@ -17,7 +17,7 @@ define KernelPackage/qca-nss-drv-pppoe
   CATEGORY:=Kernel modules
   SUBMENU:=Network Devices
   TITLE:=Kernel driver for NSS (connection manager) - PPPoE
-  DEPENDS:=@TARGET_ipq807x +kmod-qca-nss-drv +kmod-pppoe
+  DEPENDS:=@TARGET_ipq807x +kmod-qca-nss-drv +kmod-ppp +kmod-pppoe
   FILES:=$(PKG_BUILD_DIR)/pppoe/qca-nss-pppoe.ko
   AUTOLOAD:=$(call AutoLoad,51,qca-nss-pppoe)
 endef


### PR DESCRIPTION
This fixes a dependency issue that was not allowing qca-nss-clients to show up in menuconfig unless kmod-ppp was selected


Signed-off-by: Tiago Gaspar <tiagogaspar8@gmail.com>