### PR TITLE
Add ipq806x support

### DIFF
--- a/qca/qca-nss-drv/Makefile
+++ b/qca/qca-nss-drv/Makefile
@@ -20,7 +20,9 @@ define KernelPackage/qca-nss-drv
   SECTION:=kernel
   CATEGORY:=Kernel modules
   SUBMENU:=Network Devices
-  DEPENDS:=@(TARGET_ipq807x||TARGET_ipq60xx) +kmod-qca-nss-dp
+  DEPENDS:=@(TARGET_ipq806x||TARGET_ipq807x||TARGET_ipq60xx) \
+    +TARGET_ipq807x:kmod-qca-nss-dp \
+    +TARGET_ipq806x:kmod-qca-nss-gmac
   TITLE:=Kernel driver for NSS (core driver)
   FILES:=$(PKG_BUILD_DIR)/qca-nss-drv.ko
   AUTOLOAD:=$(call AutoLoad,32,qca-nss-drv)
@@ -52,7 +54,7 @@ endef
 
 EXTRA_CFLAGS+= -I$(STAGING_DIR)/usr/include/qca-nss-gmac -I$(STAGING_DIR)/usr/include/qca-nss-dp -I$(STAGING_DIR)/usr/include/qca-ssdk
 
-ifneq (, $(findstring $(CONFIG_TARGET_BOARD), "ipq807x" "ipq60xx"))
+ifneq (, $(findstring $(CONFIG_TARGET_BOARD), "ipq807x" "ipq60xx", "ipq806x"))
 EXTRA_CFLAGS+= -DNSS_MEM_PROFILE_MEDIUM
 LOW_MEM_PROFILE_MAKE_OPTS=y
 endif
@@ -99,12 +101,20 @@ ifeq ($(CONFIG_TARGET_BOARD), "ipq807x")
     SOC="ipq807x_64"
 else ifeq ($(CONFIG_TARGET_BOARD), "ipq60xx")
     SOC="ipq60xx_64"
+else
+    SOC=$(CONFIG_TARGET_BOARD)
+endif
+
+ifeq ($(CONFIG_TARGET_BOARD), "ipq806x")
+	TARGET_NSS_MINOR_VERSION=0
+else
+	TARGET_NSS_MINOR_VERSION=3
 endif
 
 define Build/Configure
 	$(LN) arch/nss_$(SOC).h $(PKG_BUILD_DIR)/exports/nss_arch.h
 	sed -i "s/define NSS_FW_VERSION_MAJOR.*/define NSS_FW_VERSION_MAJOR 11/" $(PKG_BUILD_DIR)/exports/nss_fw_version.h
-	sed -i "s/define NSS_FW_VERSION_MINOR.*/define NSS_FW_VERSION_MINOR 3/" $(PKG_BUILD_DIR)/exports/nss_fw_version.h
+	sed -i "s/define NSS_FW_VERSION_MINOR.*/define NSS_FW_VERSION_MINOR $(TARGET_NSS_MINOR_VERSION)/" $(PKG_BUILD_DIR)/exports/nss_fw_version.h
 endef
 
 define Build/Compile

--- a/qca/qca-nss-drv/patches/999-2-treewide-add-initial-support-for-nss-firmware-11.2.patch
+++ b/qca/qca-nss-drv/patches/999-2-treewide-add-initial-support-for-nss-firmware-11.2.patch
@@ -1,0 +1,239 @@
+From e29e2d7f83a7cfafcb8089da886ac02c2f4f7c7c Mon Sep 17 00:00:00 2001
+From: Ansuel Smith <ansuelsmth@gmail.com>
+Date: Tue, 15 Jun 2021 15:33:10 +0200
+Subject: [PATCH] treewide: add initial support for nss firmware 11.2
+
+Remove not supported feature to make 11.2 firmware working.
+
+Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>
+---
+ exports/nss_ipv4.h |  4 ++++
+ exports/nss_ipv6.h |  4 ++++
+ exports/nss_n2h.h  | 18 ++++++++++++++++++
+ nss_ipv4_strings.c |  2 ++
+ nss_ipv6_strings.c |  2 ++
+ nss_n2h_stats.c    | 14 ++++++++++++--
+ nss_n2h_strings.c  | 12 ++++++++++++
+ 7 files changed, 54 insertions(+), 2 deletions(-)
+
+diff --git a/exports/nss_ipv4.h b/exports/nss_ipv4.h
+index 25c4d82..18a70db 100644
+--- a/exports/nss_ipv4.h
++++ b/exports/nss_ipv4.h
+@@ -611,8 +611,10 @@ struct nss_ipv4_rule_create_msg {
+ 			/**< RPS parameter. */
+ 	struct nss_ipv4_igs_rule igs_rule;
+ 			/**< Ingress shaping related accleration parameters. */
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,3))
+ 	struct nss_ipv4_identifier_rule identifier;
+ 			/**< Rule for adding identifier. */
++#endif
+ #if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,3))
+ 	struct nss_ipv4_mirror_rule mirror_rule;
+ 			/**< Mirror rule parameter. */
+@@ -902,10 +904,12 @@ enum nss_ipv4_exception_events {
+ 	NSS_IPV4_EXCEPTION_EVENT_MC_UPDATE_FAILURE,
+ 	NSS_IPV4_EXCEPTION_EVENT_MC_PBUF_ALLOC_FAILURE,
+ 	NSS_IPV4_EXCEPTION_EVENT_PPPOE_BRIDGE_NO_ICME,
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,2))
+ 	NSS_IPV4_EXCEPTION_EVENT_PPPOE_NO_SESSION,
+ 	NSS_IPV4_EXCEPTION_EVENT_ICMP_IPV4_GRE_HEADER_INCOMPLETE,
+ 	NSS_IPV4_EXCEPTION_EVENT_ICMP_IPV4_ESP_HEADER_INCOMPLETE,
+ 	NSS_IPV4_EXCEPTION_EVENT_EMESH_PRIO_MISMATCH,
++#endif
+ 	NSS_IPV4_EXCEPTION_EVENT_MAX
+ };
+ 
+diff --git a/exports/nss_ipv6.h b/exports/nss_ipv6.h
+index a21f939..ce9a89b 100644
+--- a/exports/nss_ipv6.h
++++ b/exports/nss_ipv6.h
+@@ -428,11 +428,13 @@ enum nss_ipv6_exception_events {
+ 	NSS_IPV6_EXCEPTION_EVENT_TUNIPIP6_NEEDS_FRAGMENTATION,
+ 	NSS_IPV6_EXCEPTION_EVENT_PPPOE_BRIDGE_NO_ICME,
+ 	NSS_IPV6_EXCEPTION_EVENT_DONT_FRAG_SET,
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,2))
+ 	NSS_IPV6_EXCEPTION_EVENT_REASSEMBLY_NOT_SUPPORTED,
+ 	NSS_IPV6_EXCEPTION_EVENT_PPPOE_NO_SESSION,
+ 	NSS_IPV6_EXCEPTION_EVENT_ICMP_IPV6_GRE_HEADER_INCOMPLETE,
+ 	NSS_IPV6_EXCEPTION_EVENT_ICMP_IPV6_ESP_HEADER_INCOMPLETE,
+ 	NSS_IPV6_EXCEPTION_EVENT_EMESH_PRIO_MISMATCH,
++#endif
+ 	NSS_IPV6_EXCEPTION_EVENT_MAX
+ };
+ 
+@@ -703,8 +705,10 @@ struct nss_ipv6_rule_create_msg {
+ 			/**< RPS parameter. */
+ 	struct nss_ipv6_igs_rule igs_rule;
+ 			/**< Ingress shaping related accleration parameters. */
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,2))
+ 	struct nss_ipv6_identifier_rule identifier;
+ 			/**< Rule for adding identifier. */
++#endif
+ #if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,3))
+ 	struct nss_ipv6_mirror_rule mirror_rule;
+ 			/**< Mirror rule parameter. */
+diff --git a/exports/nss_n2h.h b/exports/nss_n2h.h
+index 1613f41..a5e37f6 100644
+--- a/exports/nss_n2h.h
++++ b/exports/nss_n2h.h
+@@ -77,18 +77,30 @@ enum nss_n2h_stats_types {
+ 	NSS_N2H_STATS_TOTAL_TICKS,	/**< Total clock ticks spend inside the N2H. */
+ 	NSS_N2H_STATS_WORST_CASE_TICKS,	/**< Worst case iteration of the exception path in ticks. */
+ 	NSS_N2H_STATS_ITERATIONS,	/**< Number of iterations around the N2H. */
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,2))
+ 	NSS_N2H_STATS_PBUF_OCM_TOTAL_COUNT,	/**< Number of pbuf OCM total count. */
+ 	NSS_N2H_STATS_PBUF_OCM_FREE_COUNT,	/**< Number of pbuf OCM free count. */
+ 	NSS_N2H_STATS_PBUF_OCM_ALLOC_FAILS_WITH_PAYLOAD,
+ 					/**< Number of pbuf OCM allocations that have failed with payload. */
+ 	NSS_N2H_STATS_PBUF_OCM_ALLOC_FAILS_NO_PAYLOAD,
++#else
++	NSS_N2H_STATS_PBUF_OCM_ALLOC_FAILS,	/* Number of pbuf ocm allocations that have failed */
++	NSS_N2H_STATS_PBUF_OCM_FREE_COUNT,	/* Number of pbuf ocm free count */
++	NSS_N2H_STATS_PBUF_OCM_TOTAL_COUNT,	/* Number of pbuf ocm total count */
++#endif
+ 					/**< Number of pbuf OCM allocations that have failed without payload. */
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,2))
+ 	NSS_N2H_STATS_PBUF_DEFAULT_TOTAL_COUNT,	/**< Number of pbuf default total count. */
+ 	NSS_N2H_STATS_PBUF_DEFAULT_FREE_COUNT,	/**< Number of pbuf default free count. */
+ 	NSS_N2H_STATS_PBUF_DEFAULT_ALLOC_FAILS_WITH_PAYLOAD,
+ 					/**< Number of pbuf default allocations that have failed with payload. */
+ 	NSS_N2H_STATS_PBUF_DEFAULT_ALLOC_FAILS_NO_PAYLOAD,
+ 	/**< Number of pbuf default allocations that have failed without payload. */
++#else
++	NSS_N2H_STATS_PBUF_DEFAULT_ALLOC_FAILS,	/* Number of pbuf default allocations that have failed */
++	NSS_N2H_STATS_PBUF_DEFAULT_FREE_COUNT,	/* Number of pbuf default free count */
++	NSS_N2H_STATS_PBUF_DEFAULT_TOTAL_COUNT,	/* Number of pbuf default total count */
++#endif
+ 
+ 	NSS_N2H_STATS_PAYLOAD_ALLOC_FAILS,	/**< Number of pbuf allocations that have failed because there were no free payloads. */
+ 	NSS_N2H_STATS_PAYLOAD_FREE_COUNT,	/**< Number of free payloads that exist. */
+@@ -277,12 +289,18 @@ struct nss_n2h_wifi_payloads {
+  *	Payload buffer manager statistics.
+  */
+ struct nss_n2h_pbuf_mgr_stats {
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,2))
+ 	uint32_t pbuf_total_count;	/**< Total number of buffers, free or in use. */
+ 	uint32_t pbuf_free_count;	/**< Number of currently free buffers. */
+ 	uint32_t pbuf_alloc_fails_with_payload;
+ 					/**< Number of buffer allocation failures. */
+ 	uint32_t pbuf_alloc_fails_no_payload;
+ 					/**< Number of buffer allocation failures without payload. */
++#else
++	uint32_t pbuf_alloc_fails;	/**< Number of buffer allocation failures. */
++	uint32_t pbuf_free_count;	/**< Number of currently free buffers. */
++	uint32_t pbuf_total_count;	/**< Total number of buffers, free or in use. */
++#endif
+ };
+ 
+ /**
+diff --git a/nss_ipv4_strings.c b/nss_ipv4_strings.c
+index ce4c249..8fd6ffa 100644
+--- a/nss_ipv4_strings.c
++++ b/nss_ipv4_strings.c
+@@ -105,10 +105,12 @@ struct nss_stats_info nss_ipv4_strings_exception_stats[NSS_IPV4_EXCEPTION_EVENT_
+ 	{"mc_update_failure"			, NSS_STATS_TYPE_EXCEPTION},
+ 	{"mc_pbuf_alloc_failure"		, NSS_STATS_TYPE_EXCEPTION},
+ 	{"pppoe_bridge_no_icme"			, NSS_STATS_TYPE_EXCEPTION},
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,2))
+ 	{"pppoe_no_session"			, NSS_STATS_TYPE_DROP},
+ 	{"icmp_ipv4_gre_hdr_incomplete"		, NSS_STATS_TYPE_EXCEPTION},
+ 	{"icmp_ipv4_esp_hdr_incomplete"		, NSS_STATS_TYPE_EXCEPTION},
+ 	{"emesh_prio_mismatch"			, NSS_STATS_TYPE_EXCEPTION},
++#endif
+ };
+ 
+ /*
+diff --git a/nss_ipv6_strings.c b/nss_ipv6_strings.c
+index 29df9c9..49cfe53 100644
+--- a/nss_ipv6_strings.c
++++ b/nss_ipv6_strings.c
+@@ -81,11 +81,13 @@ struct nss_stats_info nss_ipv6_strings_exception_stats[NSS_IPV6_EXCEPTION_EVENT_
+ 	{"tunipip6_needs_fragmentation"			, NSS_STATS_TYPE_EXCEPTION},
+ 	{"pppoe_bridge_no_icme"				, NSS_STATS_TYPE_EXCEPTION},
+ 	{"dont_frag_set"				, NSS_STATS_TYPE_EXCEPTION},
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,2))
+ 	{"reassembly_not_supported"			, NSS_STATS_TYPE_EXCEPTION},
+ 	{"pppoe_no_session"				, NSS_STATS_TYPE_DROP},
+ 	{"icmp_gre_header_incomplete"			, NSS_STATS_TYPE_EXCEPTION},
+ 	{"icmp_esp_header_incomplete"			, NSS_STATS_TYPE_EXCEPTION},
+ 	{"emesh_prio_mismatch"				, NSS_STATS_TYPE_EXCEPTION},
++#endif
+ };
+ 
+ /*
+diff --git a/nss_n2h_stats.c b/nss_n2h_stats.c
+index 60ff88b..97d6139 100644
+--- a/nss_n2h_stats.c
++++ b/nss_n2h_stats.c
+@@ -130,15 +130,23 @@ void nss_n2h_stats_sync(struct nss_ctx_instance *nss_ctx, struct nss_n2h_stats_s
+ 	/*
+ 	 * pbuf manager ocm and default pool stats
+ 	 */
+-	nss_n2h_stats[id][NSS_N2H_STATS_PBUF_OCM_ALLOC_FAILS_WITH_PAYLOAD] += nnss->pbuf_ocm_stats.pbuf_alloc_fails_with_payload;
+ 	nss_n2h_stats[id][NSS_N2H_STATS_PBUF_OCM_FREE_COUNT] = nnss->pbuf_ocm_stats.pbuf_free_count;
+ 	nss_n2h_stats[id][NSS_N2H_STATS_PBUF_OCM_TOTAL_COUNT] = nnss->pbuf_ocm_stats.pbuf_total_count;
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,2))
++	nss_n2h_stats[id][NSS_N2H_STATS_PBUF_OCM_ALLOC_FAILS_WITH_PAYLOAD] += nnss->pbuf_ocm_stats.pbuf_alloc_fails_with_payload;
+ 	nss_n2h_stats[id][NSS_N2H_STATS_PBUF_OCM_ALLOC_FAILS_NO_PAYLOAD] += nnss->pbuf_ocm_stats.pbuf_alloc_fails_no_payload;
++#else
++	nss_n2h_stats[id][NSS_N2H_STATS_PBUF_OCM_ALLOC_FAILS] += nnss->pbuf_ocm_stats.pbuf_alloc_fails;
++#endif
+ 
+-	nss_n2h_stats[id][NSS_N2H_STATS_PBUF_DEFAULT_ALLOC_FAILS_WITH_PAYLOAD] += nnss->pbuf_default_stats.pbuf_alloc_fails_with_payload;
+ 	nss_n2h_stats[id][NSS_N2H_STATS_PBUF_DEFAULT_FREE_COUNT] = nnss->pbuf_default_stats.pbuf_free_count;
+ 	nss_n2h_stats[id][NSS_N2H_STATS_PBUF_DEFAULT_TOTAL_COUNT] = nnss->pbuf_default_stats.pbuf_total_count;
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,2))
+ 	nss_n2h_stats[id][NSS_N2H_STATS_PBUF_DEFAULT_ALLOC_FAILS_NO_PAYLOAD] += nnss->pbuf_default_stats.pbuf_alloc_fails_no_payload;
++	nss_n2h_stats[id][NSS_N2H_STATS_PBUF_DEFAULT_ALLOC_FAILS_WITH_PAYLOAD] += nnss->pbuf_default_stats.pbuf_alloc_fails_with_payload;
++#else
++	nss_n2h_stats[id][NSS_N2H_STATS_PBUF_DEFAULT_ALLOC_FAILS] += nnss->pbuf_default_stats.pbuf_alloc_fails;
++#endif
+ 
+ 	/*
+ 	 * payload mgr stats
+@@ -167,8 +175,10 @@ void nss_n2h_stats_sync(struct nss_ctx_instance *nss_ctx, struct nss_n2h_stats_s
+ 	 */
+ 	nss_n2h_stats[id][NSS_N2H_STATS_N2H_TOT_PAYLOADS] = nnss->tot_payloads;
+ 
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,2))
+ 	nss_n2h_stats[id][NSS_N2H_STATS_N2H_INTERFACE_INVALID] += nnss->data_interface_invalid;
+ 	nss_n2h_stats[id][NSS_N2H_STATS_ENQUEUE_RETRIES] += nnss->enqueue_retries;
++#endif
+ 
+ 	spin_unlock_bh(&nss_top->stats_lock);
+ }
+diff --git a/nss_n2h_strings.c b/nss_n2h_strings.c
+index c4c2ce5..347433b 100644
+--- a/nss_n2h_strings.c
++++ b/nss_n2h_strings.c
+@@ -38,14 +38,26 @@ struct nss_stats_info nss_n2h_strings_stats[NSS_N2H_STATS_MAX] = {
+ 	{"ticks"			, NSS_STATS_TYPE_SPECIAL},
+ 	{"worst_ticks"			, NSS_STATS_TYPE_SPECIAL},
+ 	{"iterations"			, NSS_STATS_TYPE_SPECIAL},
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,2))
+ 	{"pbuf_ocm_total_count"		, NSS_STATS_TYPE_SPECIAL},
+ 	{"pbuf_ocm_free_count"		, NSS_STATS_TYPE_SPECIAL},
+ 	{"pbuf_ocm_alloc_fail_payload"	, NSS_STATS_TYPE_SPECIAL},
+ 	{"pbuf_ocm_alloc_fail_nopayload", NSS_STATS_TYPE_SPECIAL},
++#else
++	{"pbuf_ocm_alloc_fails", NSS_STATS_TYPE_SPECIAL},
++	{"pbuf_ocm_free_count", NSS_STATS_TYPE_SPECIAL},
++	{"pbuf_ocm_total_count", NSS_STATS_TYPE_SPECIAL},
++#endif
++#if (NSS_FW_VERSION_CODE > NSS_FW_VERSION(11,2))
+ 	{"pbuf_def_total_count"		, NSS_STATS_TYPE_SPECIAL},
+ 	{"pbuf_def_free_count"		, NSS_STATS_TYPE_SPECIAL},
+ 	{"pbuf_def_alloc_fail_payload"	, NSS_STATS_TYPE_SPECIAL},
+ 	{"pbuf_def_alloc_fail_nopayload", NSS_STATS_TYPE_SPECIAL},
++#else
++	{"pbuf_def_alloc_fails"		, NSS_STATS_TYPE_SPECIAL},
++	{"pbuf_def_free_count"		, NSS_STATS_TYPE_SPECIAL},
++	{"pbuf_def_total_count"		, NSS_STATS_TYPE_SPECIAL},
++#endif
+ 	{"payload_alloc_fails"		, NSS_STATS_TYPE_SPECIAL},
+ 	{"payload_free_count"		, NSS_STATS_TYPE_SPECIAL},
+ 	{"h2n_control_pkts"		, NSS_STATS_TYPE_SPECIAL},
+-- 
+2.31.1
+

--- a/qca/qca-nss-ecm/Makefile
+++ b/qca/qca-nss-ecm/Makefile
@@ -18,7 +18,7 @@ define KernelPackage/qca-nss-ecm
   SECTION:=kernel
   CATEGORY:=Kernel modules
   SUBMENU:=Network Support
-  DEPENDS:=@(TARGET_ipq807x||TARGET_ipq60xx) \
+  DEPENDS:=@(TARGET_ipq807x||TARGET_ipq60xx||TARGET_ipq806x) \
   	+kmod-qca-nss-drv \
 	+iptables-mod-extra \
 	+kmod-ipt-conntrack \
@@ -52,7 +52,7 @@ endef
 
 EXTRA_CFLAGS+=-I$(STAGING_DIR)/usr/include/qca-nss-drv
 
-ifneq (, $(findstring $(CONFIG_TARGET_BOARD), "ipq807x" "ipq60xx"))
+ifneq (, $(findstring $(CONFIG_TARGET_BOARD), "ipq807x" "ipq60xx", "ipq806x"))
 ECM_MAKE_OPTS+= ECM_FRONT_END_NSS_ENABLE=y \
 		ECM_CLASSIFIER_HYFI_ENABLE=n \
 		ECM_MULTICAST_ENABLE=n \
@@ -64,7 +64,7 @@ ECM_MAKE_OPTS+= ECM_FRONT_END_NSS_ENABLE=y \
 		ECM_INTERFACE_SIT_ENABLE=n \
 		ECM_INTERFACE_TUNIPIP6_ENABLE=n \
 		ECM_INTERFACE_RAWIP_ENABLE=n \
-		ECM_INTERFACE_VLAN_ENABLE=n \
+		ECM_INTERFACE_VLAN_ENABLE=y \
 		ECM_CLASSIFIER_MARK_ENABLE=n \
 		ECM_CLASSIFIER_DSCP_ENABLE=n \
 		ECM_CLASSIFIER_PCC_ENABLE=n \
@@ -76,6 +76,8 @@ ifeq ($(CONFIG_TARGET_BOARD), "ipq807x")
     SOC="ipq807x_64"
 else ifeq ($(CONFIG_TARGET_BOARD), "ipq60xx")
     SOC="ipq60xx_64"
+else
+    SOC=$(CONFIG_TARGET_BOARD)
 endif
 
 define Build/InstallDev

--- a/qca/qca-nss-gmac/Makefile
+++ b/qca/qca-nss-gmac/Makefile
@@ -1,0 +1,48 @@
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=qca-nss-gmac
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://source.codeaurora.org/quic/qsdk/oss/lklm/nss-gmac
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_DATE:=2021-04-22
+PKG_SOURCE_VERSION:=171767947467662f2407d0cfff26dfb136c3fb4a
+PKG_MIRROR_HASH:=76eaee7210abfe817518590bdfc54ad051b6bb7851a203fb74dc4887b42ad71f
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/qca-nss-gmac
+  SECTION:=kernel
+  CATEGORY:=Kernel modules
+  SUBMENU:=Network Devices
+  DEPENDS:=@TARGET_ipq806x
+  TITLE:=Kernel driver for NSS gmac
+  FILES:=$(PKG_BUILD_DIR)/ipq806x/qca-nss-gmac.ko
+  AUTOLOAD:=$(call AutoLoad,31,qca-nss-gmac)
+endef
+
+define KernelPackage/qca-nss-gmac/Description
+This package contains a NSS driver for QCA chipset
+endef
+
+define Build/InstallDev
+	mkdir -p $(1)/usr/include/qca-nss-gmac
+	$(CP) $(PKG_BUILD_DIR)/ipq806x/exports/* $(1)/usr/include/qca-nss-gmac/
+endef
+
+EXTRA_CFLAGS+= \
+	-DCONFIG_NSS_DEBUG_LEVEL=4 \
+	-I$(PKG_BUILD_DIR)/nss_hal/include \
+	-I$(PKG_BUILD_DIR)/nss_hal/$(BOARD)
+
+define Build/Compile
+	$(MAKE) $(PKG_JOBS) -C "$(LINUX_DIR)" \
+		$(KERNEL_MAKE_FLAGS) \
+		$(PKG_MAKE_FLAGS) \
+		M="$(PKG_BUILD_DIR)" \
+		EXTRA_CFLAGS="$(EXTRA_CFLAGS)" \
+		modules
+endef
+
+$(eval $(call KernelPackage,qca-nss-gmac))

--- a/qca/qca-nss-gmac/patches/100-kernel-5.10-support.patch
+++ b/qca/qca-nss-gmac/patches/100-kernel-5.10-support.patch
@@ -1,0 +1,354 @@
+--- a/ipq806x/nss_gmac_dev.c
++++ b/ipq806x/nss_gmac_dev.c
+@@ -1585,7 +1585,7 @@ int32_t nss_gmac_attach(struct nss_gmac_dev *gmacdev,
+ 	}
+ 
+ 	/* ioremap addresses */
+-	gmacdev->mac_base = ioremap_nocache(reg_base,
++	gmacdev->mac_base = ioremap(reg_base,
+ 						      NSS_GMAC_REG_BLOCK_LEN);
+ 	if (!gmacdev->mac_base) {
+ 		netdev_dbg(netdev, "ioremap fail.\n");
+--- a/ipq806x/nss_gmac_ctrl.c
++++ b/ipq806x/nss_gmac_ctrl.c
+@@ -322,16 +322,15 @@ void nss_gmac_tx_rx_desc_init(struct nss
+  * (for example "ifconfig eth0").
+  * @param[in] pointer to net_device structure.
+  * @param[in] pointer to net_device_stats64 structure.
+- * @return Returns pointer to net_device_stats64 structure.
+  */
+-struct rtnl_link_stats64 *nss_gmac_get_stats64(struct net_device *netdev,
++void nss_gmac_get_stats64(struct net_device *netdev,
+ 						struct rtnl_link_stats64 *stats)
+ {
+ 	struct nss_gmac_dev *gmacdev = (struct nss_gmac_dev *)netdev_priv(netdev);
+ 	BUG_ON(gmacdev == NULL);
+ 
+ 	if (!gmacdev->data_plane_ops)
+-		return stats;
++		return;
+ 
+ 	spin_lock_bh(&gmacdev->stats_lock);
+ 	gmacdev->data_plane_ops->get_stats(gmacdev->data_plane_ctx, &gmacdev->nss_stats);
+@@ -354,8 +353,6 @@ struct rtnl_link_stats64 *nss_gmac_get_s
+ 	stats->tx_fifo_errors = gmacdev->nss_stats.tx_underflow_errors;
+ 	stats->tx_window_errors = gmacdev->nss_stats.tx_late_collision_errors;
+ 	spin_unlock_bh(&gmacdev->stats_lock);
+-
+-	return stats;
+ }
+ 
+ 
+@@ -439,7 +436,7 @@ static int nss_gmac_mtnp_show(struct dev
+ static int nss_gmac_tstamp_show(struct device *dev, struct device_attribute *attr, char *buf)
+ {
+ 	struct nss_gmac_dev *gmacdev = (struct nss_gmac_dev *)netdev_priv(to_net_dev(dev));
+-	struct timeval tv;
++	struct timespec64 ts64;
+ 	uint32_t ret, timeout;
+ 	uint32_t ts_hi, ts_lo;
+ 
+@@ -459,11 +456,12 @@ static int nss_gmac_tstamp_show(struct d
+ 		return -1;
+ 	}
+ 
+-	do_gettimeofday(&tv);
++	ktime_get_real_ts64(&ts64);
+ 
+ 	ret = snprintf(
+ 		buf, PAGE_SIZE,
+-		"sec:%u nsec:%u time-of-day: %12d.%06d \n", ts_hi, ts_lo, (int)tv.tv_sec, (int)tv.tv_usec);
++		"sec:%u nsec:%u time-of-day: %12d.%06d \n", \
++		ts_hi, ts_lo, (int)ts64.tv_sec, (int)(ts64.tv_nsec / NSEC_PER_USEC));
+ 
+ 	return ret;
+ }
+@@ -951,7 +949,7 @@ static const struct net_device_ops nss_g
+  * @param[in] pointer to advertised features
+  * @return void
+  */
+-static void nss_gmac_update_features(uint32_t *supp, uint32_t *adv)
++static void nss_gmac_update_features(long unsigned int *supp, long unsigned int *adv)
+ {
+ 	*supp |= NSS_GMAC_SUPPORTED_FEATURES;
+ 	*adv |= NSS_GMAC_ADVERTISED_FEATURES;
+@@ -960,6 +960,7 @@ static int32_t nss_gmac_of_get_pdata(struct device_node *np,
+ 	uint8_t *maddr = NULL;
+ 	struct nss_gmac_dev *gmacdev = (struct nss_gmac_dev *)netdev_priv(netdev);
+ 	struct resource memres_devtree = {0};
++	int ret;
+ 
+ 	if (of_property_read_u32(np, "qcom,id", &gmacdev->macid)
+ 		|| of_property_read_u32(np, "qcom,phy-mdio-addr",
+@@ -985,7 +986,10 @@ static int32_t nss_gmac_of_get_pdata(struct device_node *np,
+ 
+ 	of_property_read_u32(np, "qcom,aux-clk-freq", &gmacdev->aux_clk_freq);
+ 
+-	gmaccfg->phy_mii_type = of_get_phy_mode(np);
++	ret = of_get_phy_mode(np, &gmaccfg->phy_mii_type);
++	if (ret)
++		return ret;
++
+ 	netdev->irq = irq_of_parse_and_map(np, 0);
+ 	if (netdev->irq == NO_IRQ) {
+ 		pr_err("%s: Can't map interrupt\n", np->name);
+@@ -1063,7 +1063,7 @@ static int32_t nss_gmac_do_common_init(struct platform_device *pdev)
+ 	ctx.msm_clk_ctl_enabled = true;
+ #endif
+ 
+-	ctx.nss_base = (uint8_t *)ioremap_nocache(res_nss_base.start,
++	ctx.nss_base = (uint8_t *)ioremap(res_nss_base.start,
+ 						  resource_size(&res_nss_base));
+ 	if (!ctx.nss_base) {
+ 		pr_info("Error mapping NSS GMAC registers\n");
+@@ -1072,7 +1072,7 @@ static int32_t nss_gmac_do_common_init(struct platform_device *pdev)
+ 	}
+ 	pr_debug("%s: NSS base ioremap OK.\n", __func__);
+ 
+-	ctx.qsgmii_base = (uint32_t *)ioremap_nocache(res_qsgmii_base.start,
++	ctx.qsgmii_base = (uint32_t *)ioremap(res_qsgmii_base.start,
+ 					      resource_size(&res_qsgmii_base));
+ 	if (!ctx.qsgmii_base) {
+ 		pr_info("Error mapping QSGMII registers\n");
+@@ -1082,7 +1082,7 @@ static int32_t nss_gmac_do_common_init(struct platform_device *pdev)
+ 	pr_debug("%s: QSGMII base ioremap OK, vaddr = 0x%p\n",
+ 						__func__, ctx.qsgmii_base);
+ 
+-	ctx.clk_ctl_base = (uint32_t *)ioremap_nocache(res_clk_ctl_base.start,
++	ctx.clk_ctl_base = (uint32_t *)ioremap(res_clk_ctl_base.start,
+ 				       resource_size(&res_clk_ctl_base));
+ 	if (!ctx.clk_ctl_base) {
+ 		pr_info("Error mapping Clk control registers\n");
+@@ -1409,8 +1407,8 @@ static int32_t nss_gmac_probe(struct pla
+ 			goto nss_gmac_phy_attach_fail;
+ 		}
+ 
+-		nss_gmac_update_features(&(gmacdev->phydev->supported),
+-					&(gmacdev->phydev->advertising));
++		nss_gmac_update_features(gmacdev->phydev->supported,
++					 gmacdev->phydev->advertising);
+ 		gmacdev->phydev->irq = PHY_POLL;
+ 		netdev_dbg(netdev, "PHY %s attach OK\n", phy_id);
+ 
+@@ -1440,6 +1438,8 @@ static int32_t nss_gmac_probe(struct pla
+ 		netdev_dbg(netdev, "%s MII_PHYSID2 - 0x%04x\n", netdev->name,
+ 		      nss_gmac_mii_rd_reg(gmacdev, gmacdev->phy_base, MII_PHYSID2));
+ 	} else if (gmacdev->phy_base != NSS_GMAC_NO_MDIO_PHY) {
++		SET_NETDEV_DEV(netdev, gmacdev->miibus->parent);
++
+ 		/*
+ 		 * Issue a phy_attach for the interface connected to a switch
+ 		 */
+--- a/ipq806x/nss_gmac_ethtool.c
++++ b/ipq806x/nss_gmac_ethtool.c
+@@ -143,10 +143,10 @@ static const struct nss_gmac_ethtool_sta
+ /**
+  * @brief Array of strings describing private flag names
+  */
+-static const char *gmac_strings_priv_flags[] = {
+-	"linkpoll",
+-	"tstamp",
+-	"ignore_rx_csum_err",
++static const char *gmac_strings_priv_flags[][ETH_GSTRING_LEN] = {
++	{"linkpoll"},
++	{"tstamp"},
++	{"ignore_rx_csum_err"},
+ };
+ 
+ #define NSS_GMAC_STATS_LEN	ARRAY_SIZE(gmac_gstrings_stats)
+@@ -292,6 +292,7 @@ static int nss_gmac_set_pauseparam(struc
+ {
+ 	struct nss_gmac_dev *gmacdev = (struct nss_gmac_dev *)netdev_priv(netdev);
+ 	struct phy_device *phydev;
++	long unsigned int *advertising;
+ 
+ 	BUG_ON(gmacdev == NULL);
+ 	BUG_ON(gmacdev->netdev != netdev);
+@@ -327,14 +328,15 @@ static int nss_gmac_set_pauseparam(struc
+ 	phydev = gmacdev->phydev;
+ 
+ 	/* Update flow control advertisment */
+-	phydev->advertising &= ~(ADVERTISED_Pause | ADVERTISED_Asym_Pause);
++	advertising = phydev->advertising;
++	*advertising &= ~(ADVERTISED_Pause | ADVERTISED_Asym_Pause);
+ 
+ 	if (gmacdev->pause & FLOW_CTRL_RX)
+-		phydev->advertising |=
++		*advertising |=
+ 				(ADVERTISED_Pause | ADVERTISED_Asym_Pause);
+ 
+ 	if (gmacdev->pause & FLOW_CTRL_TX)
+-		phydev->advertising |= ADVERTISED_Asym_Pause;
++		*advertising |= ADVERTISED_Asym_Pause;
+ 
+ 	genphy_config_aneg(gmacdev->phydev);
+ 
+@@ -396,12 +398,13 @@ static uint32_t nss_gmac_get_msglevel(st
+  * @param[in] pointer to struct net_device.
+  * @param[in] pointer to struct ethtool_cmd.
+  */
+-static int32_t nss_gmac_get_settings(struct net_device *netdev,
+-			      struct ethtool_cmd *ecmd)
++static int nss_gmac_get_settings(struct net_device *netdev,
++				 struct ethtool_link_ksettings *elk)
+ {
+ 	struct nss_gmac_dev *gmacdev = (struct nss_gmac_dev *)netdev_priv(netdev);
+ 	struct phy_device *phydev = NULL;
+ 	uint16_t phyreg;
++	u32 lp_advertising = 0;
+ 
+ 	BUG_ON(gmacdev == NULL);
+ 
+@@ -413,10 +416,10 @@ static int32_t nss_gmac_get_settings(str
+ 	 */
+ 	if (!test_bit(__NSS_GMAC_LINKPOLL, &gmacdev->flags)) {
+ 		if (gmacdev->forced_speed != SPEED_UNKNOWN) {
+-			ethtool_cmd_speed_set(ecmd, gmacdev->forced_speed);
+-			ecmd->duplex = gmacdev->forced_duplex;
+-			ecmd->mdio_support = 0;
+-			ecmd->lp_advertising = 0;
++			elk->base.speed = gmacdev->forced_speed;
++			elk->base.duplex = gmacdev->forced_duplex;
++			elk->base.mdio_support = 0;
++			ethtool_convert_legacy_u32_to_link_mode(elk->link_modes.lp_advertising, 0);
+ 			return 0;
+ 		} else {
+ 			/* Non-link polled interfaced must have a forced
+@@ -432,56 +432,59 @@ static int32_t nss_gmac_get_settings(struct net_device *netdev,
+ 
+ 	/* update PHY status */
+ 	if (phydev->is_c45 == true) {
+-		ecmd->mdio_support = ETH_MDIO_SUPPORTS_C45;
++		elk->base.mdio_support = ETH_MDIO_SUPPORTS_C45;
+ 	} else {
+ 		if (genphy_read_status(phydev) != 0) {
+ 			return -EIO;
+ 		}
+-		ecmd->mdio_support = ETH_MDIO_SUPPORTS_C22;
++		elk->base.mdio_support = ETH_MDIO_SUPPORTS_C22;
+ 	}
+ 
+ 	/* Populate capabilities advertised by self */
+-	ecmd->advertising = phydev->advertising;
++	bitmap_copy(elk->link_modes.advertising, phydev->advertising, __ETHTOOL_LINK_MODE_MASK_NBITS);
+ 
+-	ecmd->autoneg = phydev->autoneg;
+-	ethtool_cmd_speed_set(ecmd, phydev->speed);
+-	ecmd->duplex = phydev->duplex;
+-	ecmd->port = PORT_TP;
+-	ecmd->phy_address = gmacdev->phy_base;
+-	ecmd->transceiver = XCVR_EXTERNAL;
++	elk->base.autoneg = phydev->autoneg;
++	elk->base.speed = phydev->speed;
++	elk->base.duplex = phydev->duplex;
++	elk->base.port = PORT_TP;
++	elk->base.phy_address = gmacdev->phy_base;
++	elk->base.transceiver = XCVR_EXTERNAL;
+ 
+ 	/* Populate supported capabilities */
+-	ecmd->supported = phydev->supported;
++	bitmap_copy(elk->link_modes.supported, phydev->supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
+ 
+ 	if (phydev->is_c45 == true)
+ 		return 0;
+ 
+ 	/* Populate capabilities advertised by link partner */
++	ethtool_convert_link_mode_to_legacy_u32(&lp_advertising, elk->link_modes.lp_advertising);
+ 	phyreg = nss_gmac_mii_rd_reg(gmacdev, gmacdev->phy_base, MII_LPA);
+ 	if (phyreg & LPA_10HALF)
+-		ecmd->lp_advertising |= ADVERTISED_10baseT_Half;
++		lp_advertising |= ADVERTISED_10baseT_Half;
+ 
+ 	if (phyreg & LPA_10FULL)
+-		ecmd->lp_advertising |= ADVERTISED_10baseT_Full;
++		lp_advertising |= ADVERTISED_10baseT_Full;
+ 
+ 	if (phyreg & LPA_100HALF)
+-		ecmd->lp_advertising |= ADVERTISED_100baseT_Half;
++		lp_advertising |= ADVERTISED_100baseT_Half;
+ 
+ 	if (phyreg & LPA_100FULL)
+-		ecmd->lp_advertising |= ADVERTISED_100baseT_Full;
++		lp_advertising |= ADVERTISED_100baseT_Full;
+ 
+ 	if (phyreg & LPA_PAUSE_CAP)
+-		ecmd->lp_advertising |= ADVERTISED_Pause;
++		lp_advertising |= ADVERTISED_Pause;
+ 
+ 	if (phyreg & LPA_PAUSE_ASYM)
+-		ecmd->lp_advertising |= ADVERTISED_Asym_Pause;
++		lp_advertising |= ADVERTISED_Asym_Pause;
+ 
+ 	phyreg = nss_gmac_mii_rd_reg(gmacdev, gmacdev->phy_base, MII_STAT1000);
+ 	if (phyreg & LPA_1000HALF)
+-		ecmd->lp_advertising |= ADVERTISED_1000baseT_Half;
++		lp_advertising |= ADVERTISED_1000baseT_Half;
+ 
+ 	if (phyreg & LPA_1000FULL)
+-		ecmd->lp_advertising |= ADVERTISED_1000baseT_Full;
++		lp_advertising |= ADVERTISED_1000baseT_Full;
++
++	ethtool_convert_legacy_u32_to_link_mode(elk->link_modes.lp_advertising, lp_advertising);
+ 
+ 	return 0;
+ }
+@@ -489,8 +495,8 @@ static int32_t nss_gmac_get_settings(str
+  * @param[in] pointer to struct net_device.
+  * @param[in] pointer to struct ethtool_cmd.
+  */
+-static int32_t nss_gmac_set_settings(struct net_device *netdev,
+-			      struct ethtool_cmd *ecmd)
++static int nss_gmac_set_settings(struct net_device *netdev,
++				 const struct ethtool_link_ksettings *elk)
+ {
+ 	struct nss_gmac_dev *gmacdev = (struct nss_gmac_dev *)netdev_priv(netdev);
+ 	struct phy_device *phydev = NULL;
+@@ -512,13 +518,13 @@ static int32_t nss_gmac_set_settings(str
+ 		return -EPERM;
+ 	}
+ 
+-	if (ecmd->autoneg == AUTONEG_ENABLE) {
++	if (elk->base.autoneg == AUTONEG_ENABLE) {
+ 		set_bit(__NSS_GMAC_AUTONEG, &gmacdev->flags);
+ 	} else {
+ 		clear_bit(__NSS_GMAC_AUTONEG, &gmacdev->flags);
+ 	}
+ 
+-	return phy_ethtool_sset(phydev, ecmd);
++	return phy_ethtool_ksettings_set(phydev, elk);
+ }
+ 
+ /**
+@@ -580,8 +586,8 @@ struct ethtool_ops nss_gmac_ethtool_ops
+ 	.set_pauseparam = &nss_gmac_set_pauseparam,
+ 	.nway_reset = &nss_gmac_nway_reset,
+ 	.get_wol = &nss_gmac_get_wol,
+-	.get_settings = &nss_gmac_get_settings,
+-	.set_settings = &nss_gmac_set_settings,
++	.get_link_ksettings = &nss_gmac_get_settings,
++	.set_link_ksettings = &nss_gmac_set_settings,
+ 	.get_strings = &nss_gmac_get_strings,
+ 	.get_sset_count = &nss_gmac_get_strset_count,
+ 	.get_ethtool_stats = &nss_gmac_get_ethtool_stats,
+--- a/ipq806x/nss_gmac_tx_rx_offload.c
++++ b/ipq806x/nss_gmac_tx_rx_offload.c
+@@ -1046,7 +1046,7 @@ int nss_gmac_close(struct net_device *netdev)
+  * @param[in] pointer to net_device structure
+  * @return void.
+  */
+-void nss_gmac_tx_timeout(struct net_device *netdev)
++void nss_gmac_tx_timeout(struct net_device *netdev, unsigned int txqueue)
+ {
+ 	struct nss_gmac_dev *gmacdev = (struct nss_gmac_dev *)netdev_priv(netdev);
+ 	BUG_ON(gmacdev == NULL);
+--- a/ipq806x/include/nss_gmac_network_interface.h
++++ b/ipq806x/include/nss_gmac_network_interface.h
+@@ -41,7 +41,7 @@ int32_t nss_gmac_xmit_frames(struct sk_buff *skb,
+ int32_t nss_gmac_close(struct net_device *netdev);
+ int32_t nss_gmac_open(struct net_device *netdev);
+ int32_t nss_gmac_change_mtu(struct net_device *netdev, int32_t newmtu);
+-void nss_gmac_tx_timeout(struct net_device *netdev);
++void nss_gmac_tx_timeout(struct net_device *netdev, unsigned int txqueue);
+ 
+ /* NSS driver interface APIs */
+ void nss_gmac_receive(struct net_device *netdev, struct sk_buff *skb,

--- a/qca/qca-nss-gmac/patches/101-fix-error-with-missing-mac-addr.patch
+++ b/qca/qca-nss-gmac/patches/101-fix-error-with-missing-mac-addr.patch
@@ -1,0 +1,11 @@
+--- a/ipq806x/nss_gmac_ctrl.c
++++ b/ipq806x/nss_gmac_ctrl.c
+@@ -992,7 +992,7 @@ static int32_t nss_gmac_of_get_pdata(str
+ 		return -EFAULT;
+ 	}
+ 	maddr = (uint8_t *)of_get_mac_address(np);
+-	if (maddr)
++	if (!IS_ERR_OR_NULL(maddr))
+ 		memcpy(gmaccfg->mac_addr, maddr, ETH_ALEN);
+ 
+ 	if (of_address_to_resource(np, 0, &memres_devtree) != 0)

--- a/qca/qca-nss-gmac/patches/200-work-around-interface-close-warning.patch
+++ b/qca/qca-nss-gmac/patches/200-work-around-interface-close-warning.patch
@@ -1,0 +1,15 @@
+--- a/ipq806x/nss_gmac_tx_rx_offload.c
++++ b/ipq806x/nss_gmac_tx_rx_offload.c
+@@ -1027,8 +1027,10 @@ int nss_gmac_close(struct net_device *ne
+ 	nss_gmac_disable_interrupt_all(gmacdev);
+ 	gmacdev->data_plane_ops->link_state(gmacdev->data_plane_ctx, 0);
+ 
+-	if (!IS_ERR(gmacdev->phydev))
+-		phy_stop(gmacdev->phydev);
++	if (!IS_ERR(gmacdev->phydev)) {
++		if (test_bit(__NSS_GMAC_LINKPOLL, &gmacdev->flags))
++			phy_stop(gmacdev->phydev);
++	}
+ 
+ 	clear_bit(__NSS_GMAC_UP, &gmacdev->flags);
+ 	clear_bit(__NSS_GMAC_CLOSING, &gmacdev->flags);

--- a/qca/qca-ssdk/Makefile
+++ b/qca/qca-ssdk/Makefile
@@ -17,7 +17,7 @@ define KernelPackage/qca-ssdk-nohnat
   CATEGORY:=Kernel modules
   SUBMENU:=Network Devices
   TITLE:=Kernel driver for QCA SSDK
-  DEPENDS:=@(TARGET_ipq807x)
+  DEPENDS:=@(TARGET_ipq807x||TARGET_ipq806x)
   FILES:=$(PKG_BUILD_DIR)/build/bin/qca-ssdk.ko
   AUTOLOAD:=$(call AutoLoad,30,qca-ssdk)
 endef
@@ -46,7 +46,7 @@ MAKE_FLAGS+= \
 	EXTRA_CFLAGS=-I$(STAGING_DIR)/usr/include \
 	$(KERNEL_MAKE_FLAGS)
 
-ifneq (, $(findstring $(CONFIG_TARGET_BOARD), "ipq60xx" "ipq807x"))
+ifneq (, $(findstring $(CONFIG_TARGET_BOARD), "ipq60xx" "ipq807x" "ipq806x"))
     MAKE_FLAGS+= PTP_FEATURE=disable SWCONFIG_FEATURE=disable
 endif
 
@@ -54,6 +54,8 @@ ifeq ($(CONFIG_TARGET_BOARD), "ipq807x")
     MAKE_FLAGS+= CHIP_TYPE=HPPE
 else ifeq ($(CONFIG_TARGET_BOARD), "ipq60xx")
     MAKE_FLAGS+= CHIP_TYPE=CPPE
+else ifeq ($(CONFIG_TARGET_BOARD), "ipq806x")
+    MAKE_FLAGS+= HK_CHIP=enable CHIP_TYPE=MP
 endif
 
 define Build/InstallDev

--- a/qca/qca-ssdk/patches/0001-SSDK-config-add-kernel-5.10.patch
+++ b/qca/qca-ssdk/patches/0001-SSDK-config-add-kernel-5.10.patch
@@ -25,6 +25,27 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  ifeq ($(KVER), 3.4.0)
  OS_VER=3_4
  endif
+@@ -105,7 +109,7 @@ endif
+ ifeq ($(KVER), 3.18.21)
+   CPU_CFLAG=-D__LINUX_ARM_ARCH__=7  -DMODULE -fno-common -DCONFIG_MMU -D$(BOARD_NAME)
+ endif
+-ifeq ($(KVER),$(filter 4.4% 5.4%,$(KVER)))
++ifeq ($(KVER),$(filter 4.4% 5.4% 5.10%,$(KVER)))
+   CPU_CFLAG=-D__LINUX_ARM_ARCH__=7  -DMODULE -fno-common -DCONFIG_MMU -D$(BOARD_NAME)
+ endif
+ 
+@@ -113,8 +117,9 @@ ifeq ($(KVER),$(filter 3.14%,$(KVER)))
+   CPU_CFLAG= -DMODULE -nostdinc -D$(BOARD_NAME) -mlittle-endian -Wundef -Wstrict-prototypes -Wno-trigraphs -Werror -fno-strict-aliasing -fno-common -Wno-format-security -fno-delete-null-pointer-checks -O2 -fno-dwarf2-cfi-asm -mabi=aapcs-linux -mno-thumb-interwork -mfpu=vfp -funwind-tables -marm -D__LINUX_ARM_ARCH__=7 -march=armv7-a -msoft-float -Uarm -Wframe-larger-than=1024 -fno-stack-protector -Wno-unused-but-set-variable -fomit-frame-pointer -g -Wdeclaration-after-statement -Wno-pointer-sign -fno-strict-overflow -fconserve-stack -Werror=implicit-int -DCC_HAVE_ASM_GOTO    -D"KBUILD_STR(s)=\#s" -D"KBUILD_BASENAME=KBUILD_STR(mem)"
+ endif
+ 
+-ifeq ($(KVER),$(filter 4.9% 4.4% 5.4%,$(KVER)))
+-  CPU_CFLAG= -DMODULE -nostdinc -D$(BOARD_NAME) -mlittle-endian -Wundef -Wstrict-prototypes -Wno-trigraphs -Werror -fno-strict-aliasing -fno-common -Wno-format-security -fno-delete-null-pointer-checks -O2 -fno-dwarf2-cfi-asm -mabi=aapcs-linux -mno-thumb-interwork -mfpu=vfp -funwind-tables -marm -D__LINUX_ARM_ARCH__=7 -march=armv7-a -msoft-float -Uarm -Wframe-larger-than=2048 -fno-stack-protector -Wno-unused-but-set-variable -fomit-frame-pointer -g -Wdeclaration-after-statement -Wno-pointer-sign -fno-strict-overflow -fconserve-stack -Werror=implicit-int -DCC_HAVE_ASM_GOTO    -D"KBUILD_STR(s)=\#s" -D"KBUILD_BASENAME=KBUILD_STR(mem)"
++ifeq ($(KVER),$(filter 4.9% 4.4% 5.4% 5.10%,$(KVER)))
++  CPU_CFLAG= -pipe -O2 -mcpu=cortex-a15 -mfpu=neon-vfpv4 -msoft-float -marm -mthumb-interwork -DMODULE -D$(BOARD_NAME) -mlittle-endian -Wundef -Wstrict-prototypes -Wno-trigraphs -fno-strict-aliasing -fno-common -Wno-format-security -fno-delete-null-pointer-checks -fno-dwarf2-cfi-asm -mabi=aapcs-linux -funwind-tables -D__LINUX_ARM_ARCH__=7 -Uarm -Wframe-larger-than=2048 -fno-stack-protector -Wno-unused-but-set-variable -fomit-frame-pointer -g -Wdeclaration-after-statement -Wno-pointer-sign -fno-strict-overflow -fconserve-stack -Werror=implicit-int -DCC_HAVE_ASM_GOTO    -D"KBUILD_STR(s)=\#s" -D"KBUILD_BASENAME=KBUILD_STR(mem)"
++  CFLAGS:=$(filter-out -mfloat-abi=hard,$(CFLAGS))
+ endif
+ 
+ ifeq ($(KVER),$(filter 3.18%,$(KVER)))
 @@ -123,7 +127,7 @@ endif
  endif
  


### PR DESCRIPTION
This is a testing pr to add initial support for ipq806x
Firmware 11.0 can be found online and user have to manually insert it in their image...

Aside from this a very basic image works with offload... But without nss firmware gmac driver crash and complains about dma...
Also it seems for a big image chain notifier is needed but for some reason ecm offload stop to work.

Testing env were a really light image in initramfs and this confirm that it does work. Posting the pr here so robi can check if there aren't too much hack in the changes.