### PR TITLE
qca-ssdk: disable stack protector

### DIFF
--- a/qca/qca-ssdk/Makefile
+++ b/qca/qca-ssdk/Makefile
@@ -43,7 +43,7 @@ MAKE_FLAGS+= \
 	ARCH=$(LINUX_KARCH) \
 	TARGET_SUFFIX=$(CONFIG_TARGET_SUFFIX) \
 	GCC_VERSION=$(GCC_VERSION) \
-	EXTRA_CFLAGS=-I$(STAGING_DIR)/usr/include \
+	EXTRA_CFLAGS=-fno-stack-protector -I$(STAGING_DIR)/usr/include \
 	$(KERNEL_MAKE_FLAGS)
 
 ifneq (, $(findstring $(CONFIG_TARGET_BOARD), "ipq60xx" "ipq807x"))


### PR DESCRIPTION
add -fno-stack-protector to EXTRACFLAGS
so it can be compiled with GCC10

Signed-off-by: Zhijun You <hujy652@gmail.com>