### PR TITLE
qca-ssdk: This adds support for the AQR113C with the id

### DIFF
--- a/qca/qca-ssdk/patches/0003-add-aquantia-phy-id-113CB0-0x31c31C12.patch
+++ b/qca/qca-ssdk/patches/0003-add-aquantia-phy-id-113CB0-0x31c31C12.patch
@@ -1,0 +1,44 @@
+From 440ab349813e5aa9dbeddab4d82ab64ff5347c5f Mon Sep 17 00:00:00 2001
+From: Dirk Buchwalder <buchwalder@posteo.de>
+Date: Sat, 30 Oct 2021 19:51:06 +0200
+Subject: [PATCH] add aquantia phy id 113CB0 / 0x31c31C12
+
+This adds support for the AQR113C with the id 
+"113CB0 / 0x31c31C12" to the ssdk.
+
+This is used in the QNAP 301w
+
+Signed-off-by: Dirk Buchwalder <buchwalder@posteo.de>
+
+---
+ include/hsl/phy/hsl_phy.h | 1 +
+ src/hsl/phy/hsl_phy.c     | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/include/hsl/phy/hsl_phy.h b/include/hsl/phy/hsl_phy.h
+index 4621e725..7551574a 100755
+--- a/include/hsl/phy/hsl_phy.h
++++ b/include/hsl/phy/hsl_phy.h
+@@ -579,6 +579,7 @@ typedef struct {
+ #define AQUANTIA_PHY_112        0x03a1b660
+ #define AQUANTIA_PHY_113C_A0    0x31c31C10
+ #define AQUANTIA_PHY_113C_A1    0x31c31C11
++#define AQUANTIA_PHY_113CB0     0x31c31C12
+ #define AQUANTIA_PHY_112C       0x03a1b792
+ 
+ #define PHY_805XV2              0x004DD082
+diff --git a/src/hsl/phy/hsl_phy.c b/src/hsl/phy/hsl_phy.c
+index 5866a522..02e6aeea 100755
+--- a/src/hsl/phy/hsl_phy.c
++++ b/src/hsl/phy/hsl_phy.c
+@@ -235,6 +235,7 @@ phy_type_t hsl_phytype_get_by_phyid(a_uint32_t dev_id, a_uint32_t phy_id)
+ 		case AQUANTIA_PHY_112:
+ 		case AQUANTIA_PHY_113C_A0:
+ 		case AQUANTIA_PHY_113C_A1:
++		case AQUANTIA_PHY_113CB0:
+ 		case AQUANTIA_PHY_112C:
+ 			phytype = AQUANTIA_PHY_CHIP;
+ 			break;
+-- 
+2.31.1
+


### PR DESCRIPTION
"113CB0 / 0x31c31C12" to the ssdk.

This is used in the QNAP 301w

Signed-off-by: Dirk Buchwalder <buchwalder@posteo.de>