### PR TITLE
Avoid a memcpy overflow in ecm_db

### DIFF
--- a/qca/qca-nss-ecm/patches/900-qca-nss-ecm-fix-a-memcpy-overflow-in-ecm_db.patch
+++ b/qca/qca-nss-ecm/patches/900-qca-nss-ecm-fix-a-memcpy-overflow-in-ecm_db.patch
@@ -1,0 +1,67 @@
+From 1958e34c4c1b8b4fb62eba693fbd7693536947b9 Mon Sep 17 00:00:00 2001
+From: flebourse <francis.lebourse@sfr.fr>
+Date: Thu, 23 Dec 2021 16:11:06 +0100
+Subject: [PATCH] qca-nss-ecm: fix a memcpy overflow in ecm_db
+
+Calls to ipv6_addr_prefix() trigger a memcpy overflow if the prefix len
+argument is greater than 128, cap it at this value.
+
+stack bactrace:
+detected buffer overflow in memcpy
+Kernel BUG at fortify_panic+0x20/0x24
+Internal error: Oops - BUG: 0 [#1] SMP
+CPU: 2 PID: 2592 Comm: netifd Not tainted 5.10.80 #0
+Hardware name: Xiaomi AX9000 (DT)
+Call trace:
+ fortify_panic+0x20/0x24
+ ecm_db_exit+0x42c/0x49c [ecm]
+ ecm_db_exit+0x464/0x49c [ecm]
+ atomic_notifier_call_chain+0x5c/0x90
+ ip6_route_add+0x13c/0x1a4
+ inet6_rtm_newroute+0x98/0xa0
+ rtnetlink_rcv_msg+0x10c/0x34c
+ netlink_rcv_skb+0x5c/0x130
+ rtnetlink_rcv+0x1c/0x2c
+ netlink_unicast+0x1ec/0x2e0
+ netlink_sendmsg+0x1a4/0x394
+ ____sys_sendmsg+0x270/0x2b4
+ ___sys_sendmsg+0x7c/0xc0
+ __sys_sendmsg+0x5c/0xb0
+ __arm64_sys_sendmsg+0x28/0x34
+ el0_svc_common.constprop.0+0x88/0x190
+ do_el0_svc+0x74/0x94
+ el0_svc+0x14/0x20
+ el0_sync_handler+0xa8/0x130
+ el0_sync+0x184/0x1c0
+Code: aa0003e1 912b4040 910003fd 97fff56c (d4210000)
+
+Signed-off-by: Francis Le Bourse <francis.lebourse@sfr.fr>
+---
+ ecm_db/ecm_db.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ecm_db/ecm_db.c b/ecm_db/ecm_db.c
+index c6f408d..df04afd 100644
+--- a/ecm_db/ecm_db.c
++++ b/ecm_db/ecm_db.c
+@@ -298,7 +298,7 @@ static int ecm_db_ipv6_route_table_update_event(struct notifier_block *nb,
+ 		 * Compute ECM connection's prefix destination address by masking it with the
+ 		 * route config's destination address prefix length.
+ 		 */
+-		ipv6_addr_prefix(&prefix_addr, &ecm_in6, cfg->fc_dst_len);
++		ipv6_addr_prefix(&prefix_addr, &ecm_in6, min(128, cfg->fc_dst_len));
+ 
+ 		DEBUG_TRACE("dest addr prefix: %pI6 prefix_len: %d ecm_in6: %pI6\n", &prefix_addr, cfg->fc_dst_len, &ecm_in6);
+ 
+@@ -326,7 +326,7 @@ static int ecm_db_ipv6_route_table_update_event(struct notifier_block *nb,
+ 			 * Compute ECM connection's prefix source address by masking it with the
+ 			 * route config's destination address prefix length.
+ 			 */
+-			ipv6_addr_prefix(&prefix_addr, &ecm_in6, cfg->fc_dst_len);
++			ipv6_addr_prefix(&prefix_addr, &ecm_in6, min(128, cfg->fc_dst_len));
+ 
+ 			DEBUG_TRACE("src addr prefix: %pI6 prefix_len: %d ecm_in6: %pI6\n", &prefix_addr, cfg->fc_dst_len, &ecm_in6);
+ 
+-- 
+2.1.4
+

--- a/qca/qca-nss-ecm/patches/900-qca-nss-ecm-fix-a-memcpy-overflow-in-ecm_db.patch
+++ b/qca/qca-nss-ecm/patches/900-qca-nss-ecm-fix-a-memcpy-overflow-in-ecm_db.patch
@@ -35,7 +35,7 @@ Call trace:
  el0_sync+0x184/0x1c0
 Code: aa0003e1 912b4040 910003fd 97fff56c (d4210000)
 
-Signed-off-by: Francis Le Bourse <francis.lebourse@sfr.fr>
+Signed-off-By: Francis Le Bourse <francis.lebourse@sfr.fr>
 ---
  ecm_db/ecm_db.c | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)


### PR DESCRIPTION
The prefix length argument of calls to ipv6_addr_prefix() is not checked, leading to a memcpy overflow and kernel crash if it is greater than 128.
Cap it to 128.