### PR TITLE
nss-dp: Support "phy-handle" properties for PHY connection

### DIFF
--- a/qca/qca-nss-dp/patches/0013-nss_dp_main-Use-a-phy-handle-property-to-connect-to-.patch
+++ b/qca/qca-nss-dp/patches/0013-nss_dp_main-Use-a-phy-handle-property-to-connect-to-.patch
@@ -1,0 +1,189 @@
+From 8293a26ca56ee2e9a88e4efb5dcc7f647803cd8c Mon Sep 17 00:00:00 2001
+From: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+Date: Sun, 5 Jun 2022 21:45:09 -0500
+Subject: [PATCH] nss_dp_main: Use a 'phy-handle' property to connect to the
+ PHY
+
+The original method of connecting a PHY to the ethernet controller
+requires the "qcom,link-poll", and "qcom,phy-mdio-addr" devicetree
+properties. This is redundant. The PHY node already contains the MDIO
+address, and attaching a PHY implies "link-poll".
+
+Allow using a "phy-handle" property. Remove the following properties,
+as they are no longer used:
+    * "qcom,link-poll"
+    * "qcom,phy-mdio-addr"
+    * "mdio-bus"
+    * "qcom,forced-speed"
+    * "qcom,forced-duplex"
+
+Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+---
+ include/nss_dp_dev.h |  5 +--
+ nss_dp_main.c        | 91 +++++---------------------------------------
+ 2 files changed, 10 insertions(+), 86 deletions(-)
+
+diff --git a/include/nss_dp_dev.h b/include/nss_dp_dev.h
+index 19b3e78..63a857a 100644
+--- a/include/nss_dp_dev.h
++++ b/include/nss_dp_dev.h
+@@ -100,13 +100,10 @@ struct nss_dp_dev {
+ 	unsigned long drv_flags;	/* Driver specific feature flags */
+ 
+ 	/* Phy related stuff */
++	struct device_node *phy_node;
+ 	struct phy_device *phydev;	/* Phy device */
+ 	struct mii_bus *miibus;		/* MII bus */
+ 	phy_interface_t phy_mii_type;	/* RGMII/SGMII/QSGMII */
+-	uint32_t phy_mdio_addr;		/* Mdio address */
+-	bool link_poll;			/* Link polling enable? */
+-	uint32_t forced_speed;		/* Forced speed? */
+-	uint32_t forced_duplex;		/* Forced duplex? */
+ 	uint32_t link_state;		/* Current link state */
+ 	uint32_t pause;			/* Current flow control settings */
+ 
+diff --git a/nss_dp_main.c b/nss_dp_main.c
+index 441c300..a1e8627 100644
+--- a/nss_dp_main.c
++++ b/nss_dp_main.c
+@@ -399,7 +399,7 @@ static int nss_dp_open(struct net_device *netdev)
+ 
+ 	netif_start_queue(netdev);
+ 
+-	if (!dp_priv->link_poll) {
++	if (!dp_priv->phydev) {
+ 		/* Notify data plane link is up */
+ 		if (dp_priv->data_plane_ops->link_state(dp_priv->dpc, 1)) {
+ 			netdev_dbg(netdev, "Data plane set link failed\n");
+@@ -576,6 +576,8 @@ static int32_t nss_dp_of_get_pdata(struct device_node *np,
+ 		return -EFAULT;
+ 	}
+ 
++	dp_priv->phy_node = of_parse_phandle(np, "phy-handle", 0);
++
+ 	if (of_property_read_u32(np, "qcom,mactype", &hal_pdata->mactype)) {
+ 		pr_err("%s: error reading mactype\n", np->name);
+ 		return -EFAULT;
+@@ -594,16 +596,6 @@ static int32_t nss_dp_of_get_pdata(struct device_node *np,
+ #else
+ 	of_get_phy_mode(np, &dp_priv->phy_mii_type);
+ #endif
+-	dp_priv->link_poll = of_property_read_bool(np, "qcom,link-poll");
+-	if (of_property_read_u32(np, "qcom,phy-mdio-addr",
+-		&dp_priv->phy_mdio_addr) && dp_priv->link_poll) {
+-		pr_err("%s: mdio addr required if link polling is enabled\n",
+-				np->name);
+-		return -EFAULT;
+-	}
+-
+-	of_property_read_u32(np, "qcom,forced-speed", &dp_priv->forced_speed);
+-	of_property_read_u32(np, "qcom,forced-duplex", &dp_priv->forced_duplex);
+ 
+ 	ret = of_get_mac_address(np, maddr);
+ 	if (!ret && is_valid_ether_addr(maddr)) {
+@@ -636,50 +628,6 @@ static int32_t nss_dp_of_get_pdata(struct device_node *np,
+ 	return 0;
+ }
+ 
+-/*
+- * nss_dp_mdio_attach()
+- */
+-static struct mii_bus *nss_dp_mdio_attach(struct platform_device *pdev)
+-{
+-	struct device_node *mdio_node;
+-	struct platform_device *mdio_plat;
+-	struct ipq40xx_mdio_data *mdio_data;
+-
+-	/*
+-	 * Find mii_bus using "mdio-bus" handle.
+-	 */
+-	mdio_node = of_parse_phandle(pdev->dev.of_node, "mdio-bus", 0);
+-	if (mdio_node) {
+-		return of_mdio_find_bus(mdio_node);
+-	}
+-
+-	mdio_node = of_find_compatible_node(NULL, NULL, "qcom,qca-mdio");
+-	if (!mdio_node) {
+-		mdio_node = of_find_compatible_node(NULL, NULL,
+-							"qcom,ipq40xx-mdio");
+-		if (!mdio_node) {
+-			dev_err(&pdev->dev, "cannot find mdio node by phandle\n");
+-			return NULL;
+-		}
+-	}
+-
+-	mdio_plat = of_find_device_by_node(mdio_node);
+-	if (!mdio_plat) {
+-		dev_err(&pdev->dev, "cannot find platform device from mdio node\n");
+-		of_node_put(mdio_node);
+-		return NULL;
+-	}
+-
+-	mdio_data = dev_get_drvdata(&mdio_plat->dev);
+-	if (!mdio_data) {
+-		dev_err(&pdev->dev, "cannot get mii bus reference from device data\n");
+-		of_node_put(mdio_node);
+-		return NULL;
+-	}
+-
+-	return mdio_data->mii_bus;
+-}
+-
+ #ifdef CONFIG_NET_SWITCHDEV
+ /*
+  * nss_dp_is_phy_dev()
+@@ -738,7 +686,6 @@ static int32_t nss_dp_probe(struct platform_device *pdev)
+ 	struct device_node *np = pdev->dev.of_node;
+ 	struct nss_gmac_hal_platform_data gmac_hal_pdata;
+ 	int32_t ret = 0;
+-	uint8_t phy_id[MII_BUS_ID_SIZE + 3];
+ #if defined(NSS_DP_PPE_SUPPORT)
+ 	uint32_t vsi_id;
+ 	fal_port_t port_id;
+@@ -813,37 +760,17 @@ static int32_t nss_dp_probe(struct platform_device *pdev)
+ 
+ 	dp_priv->drv_flags |= NSS_DP_PRIV_FLAG(INIT_DONE);
+ 
+-	if (dp_priv->link_poll) {
+-		dp_priv->miibus = nss_dp_mdio_attach(pdev);
+-		if (!dp_priv->miibus) {
+-			netdev_dbg(netdev, "failed to find miibus\n");
+-			goto phy_setup_fail;
+-		}
+-		snprintf(phy_id, MII_BUS_ID_SIZE + 3, PHY_ID_FMT,
+-				dp_priv->miibus->id, dp_priv->phy_mdio_addr);
+-
++	if (dp_priv->phy_node) {
+ 		SET_NETDEV_DEV(netdev, &pdev->dev);
+-
+-		dp_priv->phydev = phy_connect(netdev, phy_id,
+-				&nss_dp_adjust_link,
+-				dp_priv->phy_mii_type);
++		dp_priv->phydev = of_phy_connect(netdev, dp_priv->phy_node,
++						 &nss_dp_adjust_link, 0,
++						 dp_priv->phy_mii_type);
+ 		if (IS_ERR(dp_priv->phydev)) {
+-			netdev_dbg(netdev, "failed to connect to phy device\n");
++			dev_err(&pdev->dev, "Could not attach to PHY\n");
+ 			goto phy_setup_fail;
+ 		}
+ 
+-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0))
+-		dp_priv->phydev->advertising |=
+-			(ADVERTISED_Pause | ADVERTISED_Asym_Pause);
+-		dp_priv->phydev->supported |=
+-			(SUPPORTED_Pause | SUPPORTED_Asym_Pause);
+-#else
+-		linkmode_set_bit(ETHTOOL_LINK_MODE_Pause_BIT, dp_priv->phydev->advertising);
+-		linkmode_set_bit(ETHTOOL_LINK_MODE_Asym_Pause_BIT, dp_priv->phydev->advertising);
+-
+-		linkmode_set_bit(ETHTOOL_LINK_MODE_Pause_BIT, dp_priv->phydev->supported);
+-		linkmode_set_bit(ETHTOOL_LINK_MODE_Asym_Pause_BIT, dp_priv->phydev->supported);
+-#endif
++		phy_attached_info(dp_priv->phydev);
+ 	}
+ 
+ #if defined(NSS_DP_PPE_SUPPORT)
+-- 
+2.36.1
+


### PR DESCRIPTION
A phy-handle is a more intuitive way to declare the PHY connection
when compared to the abomination that qualcomm implemented. In the
interest of maintaing the sanity of developers porting hardware,
shield them from the abomination wth the use of 'phy-handle.

For a given PHY:

	&mdio {
		phy28: ethernet-phy@28 {
			reg = <28>;
		};
	};

The proposed way:

	dp6: better_way {
		compatible = "qcom,nss-dp";
		reg = <0x3a007000 0x200>;
		qcom,mactype = <1>;
		qcom,id = <6>;

		phy-handle = <&phy28>;
		phy-mode = "sgmii";
	};

Compare to the old way:

	dp6: old_way {
		device_type = "network";
		compatible = "qcom,nss-dp";
		qcom,id = <5>;
		reg = <0x3a007000 0x200>;
		qcom,mactype = <1>;
		qcom,id = <6>;
		qcom,phy-mdio-addr = <28>;
		phy-mode = "sgmii";
		mdio-bus = <&mdio>;
	};

