### PR TITLE
[qca-nss-dp] Rename dependencies

### DIFF
--- a/qca/qca-nss-dp/Makefile
+++ b/qca/qca-nss-dp/Makefile
@@ -18,7 +18,7 @@ define KernelPackage/qca-nss-dp
   SECTION:=kernel
   CATEGORY:=Kernel modules
   SUBMENU:=Network Devices
-  DEPENDS:=@(TARGET_ipq807x||TARGET_ipq60xx) +kmod-qca-ssdk-nohnat
+  DEPENDS:=@(TARGET_ipq807x||TARGET_ipq60xx) +kmod-qca-ssdk
   TITLE:=Kernel driver for NSS data plane
   FILES:=$(PKG_BUILD_DIR)/qca-nss-dp.ko
   AUTOLOAD:=$(call AutoLoad,31,qca-nss-dp,1)


### PR DESCRIPTION
Rename dependencies of [qca-nss-dp], from [kmod-qca-ssdk-nohat] to [kmod-qca-ssdk].